### PR TITLE
Update Plugin to work with Jetbrains Toolbox v2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Jetbrains
+.idea/

--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects.Runner/Flow.Launcher.Plugin.JetBrainsIDEProjects.Runner.csproj
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects.Runner/Flow.Launcher.Plugin.JetBrainsIDEProjects.Runner.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Flow.Launcher.Plugin.JetBrainsIDEProjects\Flow.Launcher.Plugin.JetBrainsIDEProjects.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects.Runner/Program.cs
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects.Runner/Program.cs
@@ -1,0 +1,8 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using Flow.Launcher.Plugin;
+using Flow.Launcher.Plugin.JetBrainsIDEProjects;
+
+var stuff = new JetBrainsIDEProjects();
+stuff.Init(new PluginInitContext());
+stuff.Query(new Query("", default, default, default, default));

--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects.sln
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Flow.Launcher.Plugin.JetBrainsIDEProjects", "Flow.Launcher.Plugin.JetBrainsIDEProjects\Flow.Launcher.Plugin.JetBrainsIDEProjects.csproj", "{99728BAA-237B-4440-A053-23122B335D03}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Flow.Launcher.Plugin.JetBrainsIDEProjects.Runner", "Flow.Launcher.Plugin.JetBrainsIDEProjects.Runner\Flow.Launcher.Plugin.JetBrainsIDEProjects.Runner.csproj", "{A4FBD51C-DC0A-4F30-A51F-D3DAE86B817F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{99728BAA-237B-4440-A053-23122B335D03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99728BAA-237B-4440-A053-23122B335D03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99728BAA-237B-4440-A053-23122B335D03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99728BAA-237B-4440-A053-23122B335D03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4FBD51C-DC0A-4F30-A51F-D3DAE86B817F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4FBD51C-DC0A-4F30-A51F-D3DAE86B817F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4FBD51C-DC0A-4F30-A51F-D3DAE86B817F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4FBD51C-DC0A-4F30-A51F-D3DAE86B817F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/Flow.Launcher.Plugin.JetBrainsIDEProjects.csproj
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/Flow.Launcher.Plugin.JetBrainsIDEProjects.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <AssemblyName>Flow.Launcher.Plugin.JetBrainsIDEProjects</AssemblyName>
     <PackageId>Flow.Launcher.Plugin.JetBrainsIDEProjects</PackageId>
     <Authors>kenty02</Authors>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Flow.Launcher.Plugin" Version="3.0.1" />
+    <PackageReference Include="Flow.Launcher.Plugin" Version="4.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/ToolboxCacheReader.cs
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/ToolboxCacheReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -17,6 +18,8 @@ internal static class ToolboxCacheReader
     
     private static readonly string StatePath =
         Path.Combine(ToolboxDirectoryPath, "state.json");
+    
+    private static readonly string[] BlacklistedToolIds = {"Space"};
 
     public static List<ApplicationInfo> GetApplications()
     {
@@ -31,6 +34,10 @@ internal static class ToolboxCacheReader
         var applications = new List<ApplicationInfo>();
         foreach (var tool in state.Tools)
         {
+            if (BlacklistedToolIds.Contains(tool.ToolId))
+            {
+                continue;
+            }
             var path = Path.GetFullPath(Path.Combine(tool.InstallLocation, tool.LaunchCommand));
             var icoFile =                 
                 Directory.GetParent(path)

--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/plugin.json
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/plugin.json
@@ -4,7 +4,7 @@
     "Name": "JetBrainsIDEProjects",
     "Description": "Search projects in JetBrains IDEs",
     "Author": "kenty02",
-    "Version": "1.0.2",
+    "Version": "2.0.0",
     "Language": "csharp",
     "Website": "https://github.com/kenty02/Flow.Launcher.Plugin.JetBrainsIDEProjects",
     "IcoPath": "icon.png",


### PR DESCRIPTION
Jetbrains Toolbox v2 introduced breaking changes that affected this plugin. This PR updates directories as well as uses the new state.json file found in the toolbox directory that lists the applications instead of relying on the scripts directory. This also moves the plugin to v2 as it does not have backward compatibility with Jetbrains Toolbox v1.

Fixes Issue #6

