### PR TITLE
Fix opening project with space in its path

### DIFF
--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/Main.cs
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/Main.cs
@@ -52,7 +52,7 @@ namespace Flow.Launcher.Plugin.JetBrainsIDEProjects
                         IcoPath = project.Application?.IcoFile ?? "icon.png",
                         Action = _ =>
                         {
-                            _context.API.ShellRun(project.Path, project.Application.ExePath);
+                            _context.API.ShellRun($"\"{project.Path}\"", project.Application.ExePath);
                             return true;
                         },
                         Score = score


### PR DESCRIPTION
When opening project with space in its path, the IDE opened but it just open several (depends on how many space in project path) empty file with some project path as its title. Project without space in its path and space in IDE exe path seems to be fine.

Example, when opening project with path `C:\TEST - TEST - TEST - TEST` will open something like this
![JetBrains IDE opening several empty file](https://github.com/kenty02/Flow.Launcher.Plugin.JetBrainsIDEProjects/assets/54571802/4e6031e2-db6f-48f9-8672-3956f589b915)

This pull request fix opening project with space in its path. Thank you.