### PR TITLE
Allow keeping the window open

### DIFF
--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/Main.cs
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/Main.cs
@@ -50,10 +50,19 @@ namespace Flow.Launcher.Plugin.JetBrainsIDEProjects
                         Title = project.Name,
                         SubTitle = project.Path,
                         IcoPath = project.Application?.IcoFile ?? "icon.png",
-                        Action = _ =>
+                        Action = actionContext =>
                         {
+                            var resetQuery = !actionContext.SpecialKeyState.ShiftPressed;
+                            var closeMainWindow = !actionContext.SpecialKeyState.CtrlPressed;
+
+                            if (!closeMainWindow && resetQuery)
+                            {
+                                _context.API.ChangeQuery(_context.CurrentPluginMetadata.ActionKeyword + " ");
+                            }
+
                             _context.API.ShellRun($"\"{project.Path}\"", project.Application.ExePath);
-                            return true;
+                            
+                            return closeMainWindow;
                         },
                         Score = score
                     });


### PR DESCRIPTION
Closes #15 

Since you mentioned over there that it would make sense to reset the query, I made this configurable with another hotkey (because for my usecase I'd keep the query the same for my projects).

So now:

- No additional keys pressed -> Same behaviour as before
- Ctrl pressed -> Resets the query back to `jb ` (or whatever the configured ActionKeyword may be) and keeps the window open
- Ctrl + Shift pressed -> Keeps the window open with the query left intact

---

I left the plugin version alone for now since I figured you'd want to version the plugin yourself. If I should bump it in this PR, let me know to which version that should be :)