### PR TITLE
fix: handle null exceptions for missing directories and API context

### DIFF
--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/Main.cs
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/Main.cs
@@ -14,7 +14,14 @@ namespace Flow.Launcher.Plugin.JetBrainsIDEProjects
         public void Init(PluginInitContext context)
         {
             _context = context;
-            _settings = context.API.LoadSettingJsonStorage<Settings.Settings>();
+            if (_context?.API != null)
+            {
+                _settings = _context.API.LoadSettingJsonStorage<Settings.Settings>();
+            }
+            else
+            {
+                _settings = new Settings.Settings();
+            }
         }
 
         /// <inheritdoc />

--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/RecentProjectsReader.cs
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/RecentProjectsReader.cs
@@ -120,7 +120,8 @@ internal static class RecentProjectsReader
                 .Where(file => Regex.IsMatch(Path.GetFileName(file),
                 @$"{conversion}{version}"))
                 .Select(file => new FileInfo(file))
-                .OrderByDescending(fi => fi.LastWriteTimeUtc).FirstOrDefault().Name;
+                .OrderByDescending(fi => fi.LastWriteTimeUtc).FirstOrDefault()
+                ?.Name;
             if (flMatch == null)
             {
                 Console.WriteLine($"Skipping {application.DisplayName} ({application.DisplayVersion}): Could not find matching directory: {conversion}{version}");


### PR DESCRIPTION
This PR addresses two issues related to null exceptions in the codebase.

1. **Fix null reference exception in Main Init when `_context.API` is null**
   - When running the runner, a null reference exception occurs in the `Init` method because `_context.API` is null. A null check for `_context?.API` has been added to avoid crashes when loading settings.

2. **Fix null reference exception when no matching directory is found**
   - When having an IDE that does not find a matching directory (e.g., Fleet preview), a null reference exception occurs. A null propagation operator has been added to handle cases where no directory matches the pattern, preventing a null exception.
