### PR TITLE
Feat: Pruning functionality + context menu for "open in explorer"

### DIFF
--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/Main.cs
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/Main.cs
@@ -117,6 +117,24 @@ namespace Flow.Launcher.Plugin.JetBrainsIDEProjects
                 return new List<Result>();
             var proj = (RecentProject)selectedResult.ContextData;
             var results = new List<Result>();
+            if (!proj.IsDeleted)
+            {
+                results.Add(
+                    new Result
+                    {
+                        Title = "Open in explorer",
+                        Glyph = new GlyphInfo("Segoe MDL2 Assets", "\xED43"),
+                        Action = _ =>
+                        {
+                            var projectDirPath = Regex.Replace(proj.Path, "(.*)(/)(.*\\..*)", "$1");
+                            _context.API.ShellRun($"""
+                                                   -Command "Start-Process '{projectDirPath}'"
+                                                   """, "pwsh.exe");
+                            return true;
+                        }
+                    }
+                );
+            }
 
             results.Add(
                 new Result

--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/ProjectsPruner.cs
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/ProjectsPruner.cs
@@ -1,0 +1,22 @@
+﻿using System.Linq;
+using System.Xml;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Flow.Launcher.Plugin.JetBrainsIDEProjects;
+
+public static class ProjectsPruner
+{
+    public static void Prune(RecentProject project)
+    {
+        var xmlDoc = new XmlDocument();
+        xmlDoc.Load(project.IDERecentLocationsPath!);
+        var entries = xmlDoc.GetEntries();
+        var projectEntry = entries.Cast<XmlNode>()
+            .FirstOrDefault(entry => entry.Attributes?["key"]
+                ?.Value
+                .Equals(project.Path) ?? false);
+        projectEntry?.ParentNode!.RemoveChild(projectEntry);
+        xmlDoc.Save(project.IDERecentLocationsPath!);
+    }
+}

--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/RecentProjectsReader.cs
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/RecentProjectsReader.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
-using System.Windows.Input;
 using System.Xml;
-using static System.Runtime.CompilerServices.RuntimeHelpers;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Flow.Launcher.Plugin.JetBrainsIDEProjects;
 
@@ -156,19 +154,12 @@ internal static class RecentProjectsReader
 
             var recentProjectsXML = new XmlDocument();
             recentProjectsXML.Load(recentProjectsXMLPathFinal);
-            var entries = recentProjectsXML.SelectNodes(
-                "/application/component[@name='RecentProjectsManager']/option[@name='additionalInfo']/map/entry");
 
+            var entries = recentProjectsXML.GetEntries();
             if (entries is null || entries.Count == 0)
             {
-                // try again with RiderRecentProjectsManager
-                entries = recentProjectsXML.SelectNodes(
-                "/application/component[@name='RiderRecentProjectsManager']/option[@name='additionalInfo']/map/entry");
-                if (entries is null || entries.Count == 0)
-                {
-                    Console.WriteLine($"Skipping {application.DisplayName} ({application.DisplayVersion}): No recent projects found");
-                    continue;
-                }
+                Console.WriteLine($"Skipping {application.DisplayName} ({application.DisplayVersion}): No recent projects found");
+                continue;
             }
 
             foreach (XmlNode entry in entries)
@@ -216,6 +207,7 @@ internal static class RecentProjectsReader
                 {
                     Name = name,
                     Path = path,
+                    IDERecentLocationsPath = recentProjectsXMLPathFinal,
                     Application = application,
                     LastOpened = lastOpened
                 });
@@ -243,8 +235,10 @@ public class RecentProject
 {
     public string Name { get; init; }
     public string Path { get; init; }
+    public string IDERecentLocationsPath { get; init; }
     public ApplicationInfo Application { get; init; }
     public DateTime LastOpened { get; init; }
+    public bool IsDeleted => !File.Exists(Path) && !Directory.Exists(Path);
 }
 
 /// <summary>

--- a/Flow.Launcher.Plugin.JetBrainsIDEProjects/XMLHelpers.cs
+++ b/Flow.Launcher.Plugin.JetBrainsIDEProjects/XMLHelpers.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+using System.Xml;
+
+namespace Flow.Launcher.Plugin.JetBrainsIDEProjects;
+
+#pragma warning disable CS1591
+public static class XMLHelpers
+{
+    public static XmlNodeList? GetEntries(this XmlDocument xmlDocument)
+    {
+        var entries = xmlDocument.SelectNodes(
+            "/application/component[@name='RecentProjectsManager']/option[@name='additionalInfo']/map/entry");
+
+        if (entries is null || entries.Count == 0)
+        {
+            // try again with RiderRecentProjectsManager
+            entries = xmlDocument.SelectNodes(
+                "/application/component[@name='RiderRecentProjectsManager']/option[@name='additionalInfo']/map/entry");
+        }
+
+        return entries;
+    }
+}


### PR DESCRIPTION
### Pruning functionality:
There are situations when a project has been deleted physically but still exists in IDE config files. Deleted projects pollute list of projects that can be opened and may be confused with alive projects with similar names. So I suggest to add separate result "prune all deleted projects" to projects list. Also project can be pruned by context menu item even it is not deleted. It covers situations when you want just to delete it from recent opened projects but keep alive physically
### Open in explorer:
I find this option useful. Just context menu item that open directory of project in win explorer :D
Hope you will like these two. Thank you!